### PR TITLE
Implement cart persistence and clear feature

### DIFF
--- a/src/components/BookCard.jsx
+++ b/src/components/BookCard.jsx
@@ -25,7 +25,6 @@ const BookCard = ({ book }) => {
 
   const isInCart = state.cart.some((item) => item.key === book.key);
 
-  console.log("cart:", state.cart);
 
   const [snackbarOpen, setSnackbarOpen] = useState(false);
   const [snackbarMsg, setSnackbarMsg] = useState("");

--- a/src/contexts/BookContext.jsx
+++ b/src/contexts/BookContext.jsx
@@ -1,10 +1,33 @@
-import { createContext, useReducer } from "react";
+import { createContext, useReducer, useEffect } from "react";
 import { BookReducer, initialState } from "./BookReducer";
 
 export const BookContext = createContext();
 
+const initializer = () => {
+  try {
+    const stored = JSON.parse(localStorage.getItem("bookState"));
+    if (stored) {
+      return {
+        ...initialState,
+        cart: stored.cart || [],
+        favorites: stored.favorites || [],
+      };
+    }
+  } catch (e) {
+    console.error("Failed to parse bookState from localStorage", e);
+  }
+  return initialState;
+};
+
 export const BookProvider = ({ children }) => {
-  const [state, dispatch] = useReducer(BookReducer, initialState);
+  const [state, dispatch] = useReducer(BookReducer, initialState, initializer);
+
+  useEffect(() => {
+    localStorage.setItem(
+      "bookState",
+      JSON.stringify({ cart: state.cart, favorites: state.favorites })
+    );
+  }, [state.cart, state.favorites]);
 
   return (
     <BookContext.Provider value={{ state, dispatch }}>

--- a/src/contexts/BookReducer.js
+++ b/src/contexts/BookReducer.js
@@ -40,6 +40,14 @@ export const BookReducer = (state, action) => {
         error: null,
       };
 
+    case "CLEAR_CART":
+      return {
+        ...state,
+        cart: [],
+        loading: false,
+        error: null,
+      };
+
     case "TOGGLE_FAVORITE": {
       const exists = state.favorites.find(
         (book) => book.key === action.payload.key

--- a/src/pages/Cart.jsx
+++ b/src/pages/Cart.jsx
@@ -34,6 +34,10 @@ const Cart = () => {
     dispatch({ type: "REMOVE_FROM_CART", payload: book });
   };
 
+  const handleClearCart = () => {
+    dispatch({ type: "CLEAR_CART" });
+  };
+
   return (
     <Box alignItems="center" sx={{ p: 4 }}>
       <Typography
@@ -149,8 +153,11 @@ const Cart = () => {
               <Typography variant="body1" mb={2}>
                 Subtotal: <strong>₹{subtotal}</strong>
               </Typography>
-              <Button variant="contained" color="primary" fullWidth>
+              <Button variant="contained" color="primary" fullWidth sx={{ mb: 2 }}>
                 Proceed to Checkout
+              </Button>
+              <Button variant="outlined" color="error" fullWidth onClick={handleClearCart}>
+                Clear Cart
               </Button>
             </Paper>
           </Grid>


### PR DESCRIPTION
## Summary
- persist cart and favorites in localStorage
- add `CLEAR_CART` action to reducer
- allow clearing the cart from Cart page
- remove stray console log

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6854214242208321991735032c25e7be